### PR TITLE
link fix ifs jacker

### DIFF
--- a/docs/en/Plugin.md
+++ b/docs/en/Plugin.md
@@ -15,7 +15,7 @@ External plugins not developed by the Z-Mod author.
 1. [Bambufy](https://github.com/function3d/bambufy/blob/master/README_ru.md) - Compatible with Bambu Studio, improves feed tower control, provides accurate time and material consumption estimates, reduces waste, supports Mainsail, quick color changes, and advanced printing features. CANNOT BE USED WITH THE NATIVE SCREEN.
 2. [lessWaste](https://github.com/Hrybmo/lessWaste/blob/master/README_ru.md) - a fork of BamBufy
 3. [Dryer](https://github.com/pantata/dryer) - Drying filament via heated bed
-4. [IFS Jacker](https://github.com/ninjamida/ifs_jacker_plugin) - Plugin to support the [IFS Jacker hardware mod](https://github.com/ninjamida/ifs_jacker), for auto-detection of available channel count and Klipper integration for fans / LEDs / sensors connected via an IFS Jacker
+4. [IFS Jacker](https://github.com/ninjamida/ifs_jacker_plugin) - Plugin to support the [IFS Jacker hardware mod](https://github.com/ninjamida/ifs-jacker), for auto-detection of available channel count and Klipper integration for fans / LEDs / sensors connected via an IFS Jacker
 
 To enable the repository of external plugins, run the command `ENABLE_EXTRA_PLUGINS`.
 


### PR DESCRIPTION
The underscore is incorrect in the second link; it should be ifs-jacker, not ifs_jacker.