### PR TITLE
Fix typo in Zmod example usage

### DIFF
--- a/docs/en/Zmod.md
+++ b/docs/en/Zmod.md
@@ -225,7 +225,7 @@ chmod +x ff5m.sh
 
 **Example usage in Fluidd/Mainsail console:**
 ```
-ZSSH_ON SSH_SERVER=remote.server.ru SSH_PORT=22 SSH_USER=tbot VIDEO_PORT=8080 MOON_PORT=7125 REMOTE_enN="./ff5m.sh bot1"
+ZSSH_ON SSH_SERVER=remote.server.ru SSH_PORT=22 SSH_USER=tbot VIDEO_PORT=8080 MOON_PORT=7125 REMOTE_RUN="./ff5m.sh bot1"
 ```
 
 SSH starts 3 minutes after Klipper boots and automatically restarts at the beginning of prints (via `START_PRINT` macro).


### PR DESCRIPTION
In line 228, this was corrected to RUN.